### PR TITLE
Replace tilde with en dash for number ranges

### DIFF
--- a/src/9498/en_US-kiwiyou.html
+++ b/src/9498/en_US-kiwiyou.html
@@ -1,4 +1,4 @@
 <section id="title">Grade</section>
-<section id="description"> <div class="headline"> <h2>Statement</h2> </div> <div id="problem_description" class="problem-text"> <p>Given your point on the exam (integer, in percentage), print the grade you are in. A: 90% ~ 100%, B: 80% ~ 89%, C: 70% ~ 79%, D: 60% ~ 69%, F: otherwise.</p> </div> </section>
+<section id="description"> <div class="headline"> <h2>Statement</h2> </div> <div id="problem_description" class="problem-text"> <p>Given your point on the exam (integer, in percentage), print the grade you are in. A: 90&ndash;100%, B: 80&ndash;89%, C: 70&ndash;79%, D: 60&ndash;69%, F: otherwise.</p> </div> </section>
 <section id="input"> <div class="headline"> <h2>Input</h2> </div> <div id="problem_input" class="problem-text"> <p>An integer p, denoting the point on the exam, is given on the first line. (0 &le; p &le; 100)</p> </div> </section>
 <section id="output"> <div class="headline"> <h2>Output</h2> </div> <div id="problem_output" class="problem-text"> <p>Print the grade you are in.</p> </div> </section>


### PR DESCRIPTION
The tilde symbol is seldom used to indicate a range in English.

- [X] Did you stage index file?
- [X] Did you follow [README.md](https://github.com/kiwiyou/boj-user-translation/blob/main/README.md)?
- [X] Did you follow [formatting guide](https://github.com/kiwiyou/boj-user-translation/blob/main/formatting.md)?
